### PR TITLE
Retain divisional rematch slots when filtering pre-scheduled games

### DIFF
--- a/src/utils/scheduleStartingPoint.ts
+++ b/src/utils/scheduleStartingPoint.ts
@@ -50,12 +50,12 @@ export function filterPreScheduledMatchups(
   preScheduledMatchups: Array<{ home: string; away: string; week: number }>
 ): Array<{ home: string; away: string }> {
   const preScheduledSet = new Set<string>();
-  
-  // Add both home-away and away-home combinations to the set
-  // This ensures we catch matchups regardless of which team is home/away
+
+  // Only remove the exact orientation that was pre-scheduled. This ensures
+  // home-and-home divisional series keep their unscheduled leg available for
+  // the solver even when one meeting is locked in by the starting point data.
   preScheduledMatchups.forEach(m => {
     preScheduledSet.add(`${m.home}-${m.away}`);
-    preScheduledSet.add(`${m.away}-${m.home}`);
   });
   
   return allMatchups.filter(matchup => {


### PR DESCRIPTION
## Summary
- remove only the exact pre-seeded matchup orientation so the solver keeps the unscheduled divisional leg available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902570c920883269af133b0ce55f083